### PR TITLE
Update toolhead to backfill move queue

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -186,14 +186,6 @@ class LookAheadQueue:
             # Enough moves have been queued to reach the target flush time.
             self.flush(lazy=True)
 
-class MoveQueue:
-    def __init__(self):
-        self.lookahead_queue = LookAheadQueue()
-
-    def move_queue(self):
-        # Redirect the old move_queue method to the new lookahead method
-        return self.lookahead_queue.lookahead()
-
 BUFFER_TIME_LOW = 1.0
 BUFFER_TIME_HIGH = 2.0
 BUFFER_TIME_START = 0.250
@@ -220,6 +212,7 @@ class ToolHead:
             m for n, m in self.printer.lookup_objects(module='mcu')]
         self.mcu = self.all_mcus[0]
         self.lookahead = LookAheadQueue(self)
+        self.move_queue = self.lookahead
         self.lookahead.set_flush_time(BUFFER_TIME_HIGH)
         self.commanded_pos = [0., 0., 0., 0.]
         # Velocity and acceleration control


### PR DESCRIPTION
This PR updates the ToolHead object to actually include the move_queue parameter. There's no need to have a redirect class since we can point to the lookahead class directly from the Toolhead class.

This fixes ACCURATE_HOME_Z and G29 for PRTouch on the K1 and K1 Max.